### PR TITLE
Global configuration for explainaboard client

### DIFF
--- a/explainaboard_client/__init__.py
+++ b/explainaboard_client/__init__.py
@@ -1,5 +1,4 @@
 from explainaboard_api_client import models
 from explainaboard_client.client import ExplainaboardClient
-from explainaboard_client.config import Config
 
-__all__ = ["ExplainaboardClient", "Config", "models"]
+__all__ = ["ExplainaboardClient", "models"]

--- a/explainaboard_client/__init__.py
+++ b/explainaboard_client/__init__.py
@@ -1,4 +1,12 @@
-from explainaboard_api_client import models
+from __future__ import annotations
+
+import os
+from typing import Literal
+
 from explainaboard_client.client import ExplainaboardClient
 
-__all__ = ["ExplainaboardClient", "models"]
+__all__ = ["ExplainaboardClient"]
+
+username: str | None = os.environ.get("EB_USERNAME")
+api_key: str | None = os.environ.get("EB_API_KEY")
+environment: Literal["main", "staging", "local"] = "main"

--- a/explainaboard_client/__init__.py
+++ b/explainaboard_client/__init__.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import os
 from typing import Literal
 
 from explainaboard_client.client import ExplainaboardClient
 
 __all__ = ["ExplainaboardClient"]
 
-username: str | None = os.environ.get("EB_USERNAME")
-api_key: str | None = os.environ.get("EB_API_KEY")
+username: str | None = None
+api_key: str | None = None
 environment: Literal["main", "staging", "local"] = "main"

--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 
 from explainaboard_api_client import ApiException
-from explainaboard_client import Config, ExplainaboardClient
+from explainaboard_client import ExplainaboardClient
 from tqdm import tqdm
 
 
@@ -16,19 +16,19 @@ def main():
     )
     # --- Authentication arguments
     parser.add_argument(
-        "--email",
+        "--username",
         type=str,
         required=True,
-        help="Email address used to sign in to ExplainaBoard",
+        help="Username used to sign in to ExplainaBoard",
     )
     parser.add_argument("--api_key", type=str, required=True, help="Your API key")
     parser.add_argument(
-        "--server",
+        "--environment",
         type=str,
         required=False,
         default="main",
         choices=["main", "staging", "local"],
-        help='Which server to use, "main" should be sufficient',
+        help='Which environment to use, "main" should be sufficient',
     )
     # --- Query arguments
     parser.add_argument(
@@ -46,12 +46,9 @@ def main():
     )
     args = parser.parse_args()
 
-    client_config = Config(
-        args.email,
-        args.api_key,
-        args.server,
+    client = ExplainaboardClient(
+        username=args.username, api_key=args.api_key, environment=args.environment
     )
-    client = ExplainaboardClient(client_config)
 
     system_strs = []
     for system_id in tqdm(args.system_ids, desc="retrieving system info"):

--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -3,6 +3,7 @@ import sys
 import traceback
 
 from explainaboard_api_client import ApiException
+import explainaboard_client
 from explainaboard_client import ExplainaboardClient
 from tqdm import tqdm
 
@@ -14,21 +15,20 @@ def main():
         description="A command-line tool to delete systems from the ExplainaBoard "
         "online database."
     )
-    # --- Authentication arguments
+    # ---- Authentication arguments
     parser.add_argument(
         "--username",
         type=str,
-        required=True,
-        help="Username used to sign in to ExplainaBoard",
+        default=explainaboard_client.username,
+        help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
+        "environment variable.",
     )
-    parser.add_argument("--api_key", type=str, required=True, help="Your API key")
     parser.add_argument(
-        "--environment",
+        "--api_key",
         type=str,
-        required=False,
-        default="main",
-        choices=["main", "staging", "local"],
-        help='Which environment to use, "main" should be sufficient',
+        default=explainaboard_client.api_key,
+        help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
+        "variable.",
     )
     # --- Query arguments
     parser.add_argument(
@@ -46,9 +46,9 @@ def main():
     )
     args = parser.parse_args()
 
-    client = ExplainaboardClient(
-        username=args.username, api_key=args.api_key, environment=args.environment
-    )
+    explainaboard_client.username = args.username
+    explainaboard_client.api_key = args.api_key
+    client = ExplainaboardClient()
 
     system_strs = []
     for system_id in tqdm(args.system_ids, desc="retrieving system info"):

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -7,6 +7,7 @@ from explainaboard_api_client.model.system import System
 from explainaboard_api_client.model.system_create_props import SystemCreateProps
 from explainaboard_api_client.model.system_metadata import SystemMetadata
 from explainaboard_api_client.model.system_output_props import SystemOutputProps
+import explainaboard_client
 from explainaboard_client import ExplainaboardClient
 from explainaboard_client.utils import generate_dataset_id
 
@@ -29,13 +30,21 @@ def main():
         description="A command-line tool to submit to benchmarks "
         "on the ExplainaBoard web interface."
     )
+    # ---- Authentication arguments
     parser.add_argument(
         "--username",
         type=str,
-        required=True,
-        help="Email address used to sign in to ExplainaBoard",
+        default=explainaboard_client.username,
+        help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
+        "environment variable.",
     )
-    parser.add_argument("--api_key", type=str, required=True, help="Your API key")
+    parser.add_argument(
+        "--api_key",
+        type=str,
+        default=explainaboard_client.api_key,
+        help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
+        "variable.",
+    )
 
     parser.add_argument(
         "--public", action="store_true", help="Make the evaluation results public"
@@ -55,14 +64,6 @@ def main():
 
     parser.add_argument(
         "--shared_users", type=str, nargs="+", help="Emails of users to share with"
-    )
-    parser.add_argument(
-        "--environment",
-        type=str,
-        required=False,
-        default="main",
-        choices=["main", "staging", "local"],
-        help='Which environment to use, "main" should be sufficient',
     )
     args = parser.parse_args()
 
@@ -133,9 +134,9 @@ def main():
         create_props = SystemCreateProps(
             metadata=metadata, system_output=system_output, custom_datset=None
         )
-        client = ExplainaboardClient(
-            username=args.username, api_key=args.api_key, environment=args.environment
-        )
+        explainaboard_client.username = args.username
+        explainaboard_client.api_key = args.api_key
+        client = ExplainaboardClient()
 
         result: System = client.systems_post(create_props)
         try:

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -7,7 +7,7 @@ from explainaboard_api_client.model.system import System
 from explainaboard_api_client.model.system_create_props import SystemCreateProps
 from explainaboard_api_client.model.system_metadata import SystemMetadata
 from explainaboard_api_client.model.system_output_props import SystemOutputProps
-from explainaboard_client import Config, ExplainaboardClient
+from explainaboard_client import ExplainaboardClient
 from explainaboard_client.utils import generate_dataset_id
 
 
@@ -30,7 +30,7 @@ def main():
         "on the ExplainaBoard web interface."
     )
     parser.add_argument(
-        "--email",
+        "--username",
         type=str,
         required=True,
         help="Email address used to sign in to ExplainaBoard",
@@ -57,12 +57,12 @@ def main():
         "--shared_users", type=str, nargs="+", help="Emails of users to share with"
     )
     parser.add_argument(
-        "--server",
+        "--environment",
         type=str,
         required=False,
         default="main",
         choices=["main", "staging", "local"],
-        help='Which server to use, "main" should be sufficient',
+        help='Which environment to use, "main" should be sufficient',
     )
     args = parser.parse_args()
 
@@ -133,12 +133,9 @@ def main():
         create_props = SystemCreateProps(
             metadata=metadata, system_output=system_output, custom_datset=None
         )
-        client_config = Config(
-            args.email,
-            args.api_key,
-            args.server,
+        client = ExplainaboardClient(
+            username=args.username, api_key=args.api_key, environment=args.environment
         )
-        client = ExplainaboardClient(client_config)
 
         result: System = client.systems_post(create_props)
         try:

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -1,5 +1,6 @@
 import argparse
 
+import explainaboard_client
 from explainaboard_client import ExplainaboardClient
 from explainaboard_client.config import get_frontend
 from explainaboard_client.tasks import FileType, TaskType
@@ -16,10 +17,17 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        required=True,
-        help="Email address used to sign in to ExplainaBoard",
+        default=explainaboard_client.username,
+        help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
+        "environment variable.",
     )
-    parser.add_argument("--api_key", type=str, required=True, help="Your API key")
+    parser.add_argument(
+        "--api_key",
+        type=str,
+        default=explainaboard_client.api_key,
+        help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
+        "variable.",
+    )
     # ---- System info
     parser.add_argument(
         "--task",
@@ -105,9 +113,9 @@ def main():
     )
     args = parser.parse_args()
 
-    client = ExplainaboardClient(
-        username=args.username, api_key=args.api_key, environment=args.environment
-    )
+    explainaboard_client.username = args.username
+    explainaboard_client.api_key = args.api_key
+    client = ExplainaboardClient()
 
     try:
         evaluation_data = client.evaluate_system_file(

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -1,6 +1,7 @@
 import argparse
 
-from explainaboard_client import Config, ExplainaboardClient
+from explainaboard_client import ExplainaboardClient
+from explainaboard_client.config import get_frontend
 from explainaboard_client.tasks import FileType, TaskType
 
 
@@ -13,7 +14,7 @@ def main():
     )
     # ---- Authentication arguments
     parser.add_argument(
-        "--email",
+        "--username",
         type=str,
         required=True,
         help="Email address used to sign in to ExplainaBoard",
@@ -95,21 +96,18 @@ def main():
         "--shared_users", type=str, nargs="+", help="Emails of users to share with"
     )
     parser.add_argument(
-        "--server",
+        "--environment",
         type=str,
         required=False,
         default="main",
         choices=["main", "staging", "local"],
-        help='Which server to use, "main" should be sufficient',
+        help='Which environment to use, "main" should be sufficient',
     )
     args = parser.parse_args()
 
-    client_config = Config(
-        args.email,
-        args.api_key,
-        args.server,
+    client = ExplainaboardClient(
+        username=args.username, api_key=args.api_key, environment=args.environment
     )
-    client = ExplainaboardClient(client_config)
 
     try:
         evaluation_data = client.evaluate_system_file(
@@ -129,8 +127,8 @@ def main():
             public=args.public,
             shared_users=args.shared_users,
         )
-        frontend = client_config.get_env_host_map()[args.server].frontend
-        sys_id = evaluation_data.system_id
+        frontend = get_frontend(args.environment)
+        sys_id = evaluation_data["system_id"]
         print(
             f"successfully evaluated system {args.system_name} with ID {sys_id}\n"
             f"view it at {frontend}/systems?system_id={sys_id}\n"

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import traceback
 
-from explainaboard_client import Config, ExplainaboardClient
+from explainaboard_client import ExplainaboardClient
 from explainaboard_client.utils import sanitize_for_json
 
 
@@ -15,19 +15,19 @@ def main():
     )
     # --- Authentication arguments
     parser.add_argument(
-        "--email",
+        "--username",
         type=str,
         required=True,
         help="Email address used to sign in to ExplainaBoard",
     )
     parser.add_argument("--api_key", type=str, required=True, help="Your API key")
     parser.add_argument(
-        "--server",
+        "--environment",
         type=str,
         required=False,
         default="main",
         choices=["main", "staging", "local"],
-        help='Which server to use, "main" should be sufficient',
+        help='Which environment to use, "main" should be sufficient',
     )
     # --- Query arguments
     parser.add_argument(
@@ -101,18 +101,15 @@ def main():
     )
     args = parser.parse_args()
 
-    client_config = Config(
-        args.email,
-        args.api_key,
-        args.server,
+    client = ExplainaboardClient(
+        username=args.username, api_key=args.api_key, environment=args.environment
     )
-    client = ExplainaboardClient(client_config)
     try:
         system_list: list[dict] = client.find_systems(
             system_name=args.system_name,
             task=args.task,
             dataset=args.dataset,
-            subdataset=args.subdataset,
+            sub_dataset=args.subdataset,
             split=args.split,
             creator=args.creator,
             shared_users=args.shared_users,

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import traceback
 
+import explainaboard_client
 from explainaboard_client import ExplainaboardClient
 from explainaboard_client.utils import sanitize_for_json
 
@@ -17,17 +18,16 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        required=True,
-        help="Email address used to sign in to ExplainaBoard",
+        default=explainaboard_client.username,
+        help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
+        "environment variable.",
     )
-    parser.add_argument("--api_key", type=str, required=True, help="Your API key")
     parser.add_argument(
-        "--environment",
+        "--api_key",
         type=str,
-        required=False,
-        default="main",
-        choices=["main", "staging", "local"],
-        help='Which environment to use, "main" should be sufficient',
+        default=explainaboard_client.api_key,
+        help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
+        "variable.",
     )
     # --- Query arguments
     parser.add_argument(
@@ -101,9 +101,9 @@ def main():
     )
     args = parser.parse_args()
 
-    client = ExplainaboardClient(
-        username=args.username, api_key=args.api_key, environment=args.environment
-    )
+    explainaboard_client.username = args.username
+    explainaboard_client.api_key = args.api_key
+    client = ExplainaboardClient()
     try:
         system_list: list[dict] = client.find_systems(
             system_name=args.system_name,

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -36,7 +36,7 @@ class ExplainaboardClient:
         """
         host = get_host(environment)
         api_client = ApiClient(
-            Configuration(username=username, api_key=api_key, host=host)
+            Configuration(username=username, password=api_key, host=host)
         )
         self._default_api: DefaultApi = DefaultApi(api_client)
         self._active: bool = True

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -5,12 +5,12 @@ import logging
 from multiprocessing.pool import ApplyResult
 from typing import Literal, Union
 
-from explainaboard_api_client import ApiClient
+from explainaboard_api_client import ApiClient, Configuration
 from explainaboard_api_client.api.default_api import DefaultApi
 from explainaboard_api_client.model.system_metadata import SystemMetadata
 from explainaboard_api_client.model.systems_return import SystemsReturn
 from explainaboard_api_client.models import System, SystemCreateProps, SystemOutputProps
-from explainaboard_client.config import Config
+from explainaboard_client.config import get_host
 from explainaboard_client.tasks import DEFAULT_METRICS, infer_file_type, TaskType
 from explainaboard_client.utils import (
     encode_file_to_base64,
@@ -21,14 +21,23 @@ from explainaboard_client.utils import (
 
 class ExplainaboardClient:
     # ---- Initializers, etc.
-    def __init__(self, config: Config) -> None:
+    def __init__(
+        self,
+        username: str,
+        api_key: str,
+        environment: Literal["main", "staging", "local"] = "main",
+    ) -> None:
         """Initialize the ExplainaBoard client with a specific configuration.
 
         Args:
-            config (Config): The configuration for the ExplainaBoard client.
+            username: The username used with explainaboard.
+            api_key: The API key.
+            environment: Which environment to use, main/staging/local.
         """
-        self._config: Config = config
-        api_client = ApiClient(self._config.to_client_config())
+        host = get_host(environment)
+        api_client = ApiClient(
+            Configuration(username=username, api_key=api_key, host=host)
+        )
         self._default_api: DefaultApi = DefaultApi(api_client)
         self._active: bool = True
 

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -10,6 +10,7 @@ from explainaboard_api_client.api.default_api import DefaultApi
 from explainaboard_api_client.model.system_metadata import SystemMetadata
 from explainaboard_api_client.model.systems_return import SystemsReturn
 from explainaboard_api_client.models import System, SystemCreateProps, SystemOutputProps
+import explainaboard_client
 from explainaboard_client.config import get_host
 from explainaboard_client.tasks import DEFAULT_METRICS, infer_file_type, TaskType
 from explainaboard_client.utils import (
@@ -21,22 +22,15 @@ from explainaboard_client.utils import (
 
 class ExplainaboardClient:
     # ---- Initializers, etc.
-    def __init__(
-        self,
-        username: str,
-        api_key: str,
-        environment: Literal["main", "staging", "local"] = "main",
-    ) -> None:
-        """Initialize the ExplainaBoard client with a specific configuration.
-
-        Args:
-            username: The username used with explainaboard.
-            api_key: The API key.
-            environment: Which environment to use, main/staging/local.
-        """
-        host = get_host(environment)
+    def __init__(self) -> None:
+        """Initialize the ExplainaBoard client."""
+        host = get_host(explainaboard_client.environment)
         api_client = ApiClient(
-            Configuration(username=username, password=api_key, host=host)
+            Configuration(
+                username=explainaboard_client.username,
+                password=explainaboard_client.api_key,
+                host=host,
+            )
         )
         self._default_api: DefaultApi = DefaultApi(api_client)
         self._active: bool = True

--- a/explainaboard_client/config.py
+++ b/explainaboard_client/config.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Literal, Optional
 
-from explainaboard_api_client import Configuration
-
 
 @dataclass
 class HostConfig:
@@ -31,40 +29,9 @@ ENV_HOST_MAP: defaultdict[str, HostConfig] = defaultdict(
 )
 
 
-@dataclass
-class Config:
-    """Configurations for explainaboard CLI
+def get_host(environment: Literal["main", "staging", "local"]):
+    return ENV_HOST_MAP[environment].host
 
-    Vars:
-        user_email: The email of the user
-        api_key: API key for explainaboard
-        environment: Environment where the call should be made
-        host: A custom host to use
-    """
 
-    user_email: str
-    api_key: str
-    environment: Literal["main", "staging", "local"] = "main"
-    host: Optional[str] = None
-
-    def __post_init__(self):
-        if self.environment not in {"main", "staging", "local"}:
-            raise ValueError(f"{self.environment} is not a valid environment")
-
-    @staticmethod
-    def get_env_host_map():
-        return ENV_HOST_MAP
-
-    def get_env(self):
-        return ENV_HOST_MAP[self.environment]
-
-    def to_client_config(self):
-        client_config = Configuration()
-        client_config.host = ENV_HOST_MAP[self.environment].host
-
-        if self.host:
-            client_config.host = self.host
-
-        client_config.username = self.user_email
-        client_config.password = self.api_key
-        return client_config
+def get_frontend(environment: Literal["main", "staging", "local"]):
+    return ENV_HOST_MAP[environment].frontend

--- a/explainaboard_client/tests/test_system.py
+++ b/explainaboard_client/tests/test_system.py
@@ -98,8 +98,9 @@ class TestSystem(TestEndpointsE2E):
             self._client.delete_system(sys_id)
 
     def test_find_system(self):
+        system_ids = []
         for i in range(2):
-            self._client.evaluate_system_file(
+            result = self._client.evaluate_system_file(
                 system_output_file=self._SYSTEM_OUTPUT,
                 system_output_file_type="text",
                 task="text-classification",
@@ -111,15 +112,16 @@ class TestSystem(TestEndpointsE2E):
                 split="test",
                 shared_users=["explainaboard@gmail.com"],
             )
+            system_ids.append(result["system_id"])
         all_systems = self._client.find_systems(system_name="test_cli")
         self.assertGreater(len(all_systems), 1)
         unique_names = {x["system_info"]["system_name"]: 0 for x in all_systems}
         self.assertIn("test_cli0", unique_names)
         self.assertIn("test_cli1", unique_names)
-        for x in all_systems:
+        for x in system_ids:
             try:
-                self._client.delete_system(x["system_id"])
+                self._client.delete_system(x)
             except Exception:
                 logging.getLogger("explainaboard_client_tests").warning(
-                    f"could not delete system {x['system_id']}"
+                    f"could not delete system {x}"
                 )

--- a/explainaboard_client/tests/test_user.py
+++ b/explainaboard_client/tests/test_user.py
@@ -2,7 +2,6 @@ from multiprocessing.pool import ApplyResult
 
 from explainaboard_api_client import ApiException
 from explainaboard_client.client import ExplainaboardClient
-from explainaboard_client.config import Config
 from explainaboard_client.tests.test_utils import TestEndpointsE2E
 
 
@@ -13,7 +12,9 @@ class TestUserAPI(TestEndpointsE2E):
 
     def test_401(self):
         client = ExplainaboardClient(
-            Config("invalid_username", "invalid_api_key", "staging")
+            username="invalid_username",
+            api_key="invalid_api_key",
+            environment="staging",
         )
         with self.assertRaises(ApiException):
             client.user_get()

--- a/explainaboard_client/tests/test_user.py
+++ b/explainaboard_client/tests/test_user.py
@@ -1,6 +1,7 @@
 from multiprocessing.pool import ApplyResult
 
 from explainaboard_api_client import ApiException
+import explainaboard_client
 from explainaboard_client.client import ExplainaboardClient
 from explainaboard_client.tests.test_utils import TestEndpointsE2E
 
@@ -11,11 +12,10 @@ class TestUserAPI(TestEndpointsE2E):
         self.assertEqual(user["email"], "explainaboard@gmail.com")
 
     def test_401(self):
-        client = ExplainaboardClient(
-            username="invalid_username",
-            api_key="invalid_api_key",
-            environment="staging",
-        )
+        explainaboard_client.username = "invalid_username"
+        explainaboard_client.api_key = "invalid_api_key"
+        explainaboard_client.environment = "staging"
+        client = ExplainaboardClient()
         with self.assertRaises(ApiException):
             client.user_get()
 

--- a/explainaboard_client/tests/test_utils.py
+++ b/explainaboard_client/tests/test_utils.py
@@ -3,6 +3,7 @@ import pathlib
 from typing import Final
 from unittest import TestCase
 
+import explainaboard_client
 from explainaboard_client.client import ExplainaboardClient
 
 test_artifacts_path: Final = os.path.join(
@@ -12,11 +13,10 @@ test_artifacts_path: Final = os.path.join(
 
 class TestEndpointsE2E(TestCase):
     def setUp(self):
-        self._client = ExplainaboardClient(
-            username="explainaboard@gmail.com",
-            api_key="gEoVQz7pZzlmUR8sQiu6GQ",
-            environment="staging",
-        )
+        explainaboard_client.username = "explainaboard@gmail.com"
+        explainaboard_client.api_key = "gEoVQz7pZzlmUR8sQiu6GQ"
+        explainaboard_client.environment = "staging"
+        self._client = ExplainaboardClient()
 
     def tearDown(self) -> None:
         self._client.close()

--- a/explainaboard_client/tests/test_utils.py
+++ b/explainaboard_client/tests/test_utils.py
@@ -4,13 +4,6 @@ from typing import Final
 from unittest import TestCase
 
 from explainaboard_client.client import ExplainaboardClient
-from explainaboard_client.config import Config
-
-TEST_CONFIG = Config(
-    "explainaboard@gmail.com",
-    "gEoVQz7pZzlmUR8sQiu6GQ",
-    "staging",
-)
 
 test_artifacts_path: Final = os.path.join(
     os.path.dirname(pathlib.Path(__file__)), "artifacts"
@@ -19,7 +12,11 @@ test_artifacts_path: Final = os.path.join(
 
 class TestEndpointsE2E(TestCase):
     def setUp(self):
-        self._client: ExplainaboardClient = ExplainaboardClient(TEST_CONFIG)
+        self._client = ExplainaboardClient(
+            username="explainaboard@gmail.com",
+            api_key="gEoVQz7pZzlmUR8sQiu6GQ",
+            environment="staging",
+        )
 
     def tearDown(self) -> None:
         self._client.close()


### PR DESCRIPTION
This makes the configuration for explainaboard_client global and stored in the base class. New usage would look like either:

```
$ export EB_USERNAME=xxx
$ export EB_API_KEY=yyy
$ python
>>> from explainaboard_client.client import ExplainaboardClient
>>> client = ExplainaboardClient()
>>> client.evaluate_system(...)
```

or 

```
$ python
>>> from explainaboard_client.client import ExplainaboardClient
>>> explainaboard_client.username = "xxx"
>>> explainaboard_client.api_key = "yyy"
>>> client = ExplainaboardClient()
>>> client.evaluate_system(...)
```

Asking @pfliu-nlp for review, but also pinging @OscarWang114 in case it's useful for https://github.com/neulab/explainaboard_client/issues/18