### PR TITLE
Added test for evaluate_system CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can save these into environmental variables for convenient use in the comman
 below:
 
 ```
-export EB_EMAIL="[your email]"
+export EB_USERNAME="[your username]"
 export EB_API_KEY="[your API key]"
 ```
 
@@ -41,7 +41,7 @@ page then you can use something like the following command:
 
 ```
 python -m explainaboard_client.cli.evaluate_system \
-  --email $EB_EMAIL --api_key $EB_API_KEY \
+  --username $EB_USERNAME --api_key $EB_API_KEY \
   --task [TASK_ID] \
   --system_name [MODEL_NAME] \
   --system_output_file [SYSTEM_OUTPUT] --system_output_file_type [FILE_TYPE] \
@@ -68,7 +68,7 @@ that are not supported by DataLab yet:
 
 ```
 python -m explainaboard_client.cli.evaluate_system \
-  --email $EB_EMAIL --api_key $EB_API_KEY \
+  --username $EB_USERNAME --api_key $EB_API_KEY \
   --task [TASK_ID] \
   --system_name [MODEL_NAME] \
   --system_output_file [SYSTEM_OUTPUT] --system_output_file_type [FILE_TYPE] \
@@ -85,7 +85,7 @@ be happy to help out!
 using the following syntax
 ```
 python -m explainaboard_client.cli.find_systems \
-  --email $EB_EMAIL --api_key $EB_API_KEY --output_format tsv
+  --username $EB_USERNAME --api_key $EB_API_KEY --output_format tsv
 ```
 By default this outputs in a summarized TSV format (similar to the online system
 browser), but you can set `--output_format json` to get more extensive information.
@@ -97,7 +97,7 @@ any arguments.
 command:
 ```
 python -m explainaboard_client.cli.delete_systems \
-  --email $EB_EMAIL --api_key $EB_API_KEY --system_ids XXX YYY
+  --username $EB_USERNAME --api_key $EB_API_KEY --system_ids XXX YYY
 ```
 Here the `system_ids` are the unique identifier of each system returned in the
 `system_id` field of the JSON returned by the `find_systems` command above. The system
@@ -110,7 +110,7 @@ you can follow the command below:
 
 ```shell
 python -m explainaboard_client.cli.evaluate_benchmark \
-      --email XXX  \
+      --username XXX  \
       --api_key YYY \
       --system_name your_system \
       --system_outputs submissions/* \
@@ -118,7 +118,7 @@ python -m explainaboard_client.cli.evaluate_benchmark \
       --server local
 ```
 where
-* `--email`: the email of your explainaboard account
+* `--username`: the email of your explainaboard account
 * `--api_key`: your API key
 * `--system_name`: the system name of your submission. Note: this assumes that all
 system output share one system name.

--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -87,7 +87,7 @@ def main():
         except Exception:
             print(f"Could not delete system ID {system_id}", file=sys.stderr)
             traceback.print_exc()
-    print(f"Deleted {deleted_systems} systems")
+    print(f"Deleted {deleted_systems} system{'' if deleted_systems == 1 else 's'}")
 
 
 if __name__ == "__main__":

--- a/explainaboard_client/tests/test_cli.py
+++ b/explainaboard_client/tests/test_cli.py
@@ -1,0 +1,70 @@
+from contextlib import redirect_stdout
+import io
+import os
+import re
+from unittest.mock import patch
+
+import explainaboard_client
+from explainaboard_client.cli import delete_systems, evaluate_system
+from explainaboard_client.tests.test_utils import test_artifacts_path, TestEndpointsE2E
+
+
+class TestCLI(TestEndpointsE2E):
+    _SYSTEM_OUTPUT = os.path.join(test_artifacts_path, "sst2-lstm-output.txt")
+    _DATASET = os.path.join(test_artifacts_path, "sst2-dataset.tsv")
+
+    def test_evaluate_and_delete_cli(self):
+        # Evaluate system
+        evaluate_args = [
+            "explainaboard_client.evaluate_system",
+            "--username",
+            explainaboard_client.username,
+            "--api_key",
+            explainaboard_client.api_key,
+            "--task",
+            "text-classification",
+            "--system_name",
+            "test_cli",
+            "--system_output_file",
+            self._SYSTEM_OUTPUT,
+            "--system_output_file_type",
+            "text",
+            "--dataset",
+            "sst2",
+            "--split",
+            "test",
+            "--source_language",
+            "en",
+            "--target_language",
+            "en",
+        ]
+        stdout_stream = io.StringIO()
+        with patch("sys.argv", evaluate_args), redirect_stdout(stdout_stream):
+            evaluate_system.main()
+        stdout_content = stdout_stream.getvalue()
+        # print(f'---- evaluate_system stdout ----\n{stdout_content}')
+        stdout_lines = stdout_content.strip().split("\n")
+        m = re.match(
+            r"successfully evaluated system test_cli with ID ([0-9a-f]+)",
+            stdout_lines[0],
+        )
+        self.assertIsNotNone(m, msg=f"could not match {stdout_lines[0]}")
+        sys_id = m.group(1)
+        # Delete system
+        evaluate_args = [
+            "explainaboard_client.delete_systems",
+            "--username",
+            explainaboard_client.username,
+            "--api_key",
+            explainaboard_client.api_key,
+            "--system_ids",
+            sys_id,
+            "--skip_confirmation",
+        ]
+        stdout_stream = io.StringIO()
+        with patch("sys.argv", evaluate_args), redirect_stdout(stdout_stream):
+            delete_systems.main()
+        stdout_content = stdout_stream.getvalue()
+        # print(f'---- delete_system stdout ----\n{stdout_content}')
+        stdout_lines = stdout_content.strip().split("\n")
+        self.assertEqual("Deleted 1 system", stdout_lines[-1])


### PR DESCRIPTION
This PR's main aim is adding a test for the `evaluate_system` CLI to make sure it runs properly.

In doing so I found and fixed two other issues:
1. out-of-date documentation
2. a tiny issue that delete would say "Deleted 1 systems" mistakenly adding the plural