### PR TITLE
Bump api client version to >= 0.2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={
         "console_scripts": [],
     },
-    install_requires=["explainaboard_api_client>=0.2.0", "tqdm"],
+    install_requires=["explainaboard_api_client>=0.2.8", "tqdm"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
As titled, this is required because of incompatible changes on the openapi and DB side (migrating from email to user id).