### PR TITLE
Fix user-related args in CLI by reading from env vars

### DIFF
--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -20,14 +20,12 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )
@@ -47,8 +45,12 @@ def main():
     )
     args = parser.parse_args()
 
-    explainaboard_client.username = args.username
-    explainaboard_client.api_key = args.api_key
+    explainaboard_client.username = (
+        args.username if args.username is not None else os.environ.get("EB_USERNAME")
+    )
+    explainaboard_client.api_key = (
+        args.api_key if args.api_key is not None else os.environ.get("EB_API_KEY")
+    )
     client = ExplainaboardClient()
 
     system_strs = []

--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import sys
 import traceback
@@ -19,14 +20,14 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=explainaboard_client.username,
+        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=explainaboard_client.api_key,
+        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )

--- a/explainaboard_client/cli/delete_systems.py
+++ b/explainaboard_client/cli/delete_systems.py
@@ -1,5 +1,5 @@
-import os
 import argparse
+import os
 import sys
 import traceback
 

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import os
@@ -34,14 +35,14 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=explainaboard_client.username,
+        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=explainaboard_client.api_key,
+        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -34,14 +34,12 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )
@@ -134,8 +132,14 @@ def main():
         create_props = SystemCreateProps(
             metadata=metadata, system_output=system_output, custom_datset=None
         )
-        explainaboard_client.username = args.username
-        explainaboard_client.api_key = args.api_key
+        explainaboard_client.username = (
+            args.username
+            if args.username is not None
+            else os.environ.get("EB_USERNAME")
+        )
+        explainaboard_client.api_key = (
+            args.api_key if args.api_key is not None else os.environ.get("EB_API_KEY")
+        )
         client = ExplainaboardClient()
 
         result: System = client.systems_post(create_props)

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -1,4 +1,3 @@
-import os
 import argparse
 import json
 import os

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import traceback
@@ -19,14 +20,14 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=explainaboard_client.username,
+        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=explainaboard_client.api_key,
+        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -20,14 +20,12 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )
@@ -113,8 +111,12 @@ def main():
     )
     args = parser.parse_args()
 
-    explainaboard_client.username = args.username
-    explainaboard_client.api_key = args.api_key
+    explainaboard_client.username = (
+        args.username if args.username is not None else os.environ.get("EB_USERNAME")
+    )
+    explainaboard_client.api_key = (
+        args.api_key if args.api_key is not None else os.environ.get("EB_API_KEY")
+    )
     client = ExplainaboardClient()
 
     try:

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -1,6 +1,6 @@
-import os
 import argparse
 import json
+import os
 import traceback
 
 import explainaboard_client

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import traceback
@@ -18,14 +19,14 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=explainaboard_client.username,
+        default=os.environ.get("EB_USERNAME"),
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=explainaboard_client.api_key,
+        default=os.environ.get("EB_API_KEY"),
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -19,14 +19,12 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default="",
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default="",
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -19,14 +19,14 @@ def main():
     parser.add_argument(
         "--username",
         type=str,
-        default=os.environ.get("EB_USERNAME"),
+        default="",
         help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
         "environment variable.",
     )
     parser.add_argument(
         "--api-key",
         type=str,
-        default=os.environ.get("EB_API_KEY"),
+        default="",
         help="API key for ExplainaBoard. Defaults to the EB_API_KEY environment "
         "variable.",
     )
@@ -102,8 +102,12 @@ def main():
     )
     args = parser.parse_args()
 
-    explainaboard_client.username = args.username
-    explainaboard_client.api_key = args.api_key
+    explainaboard_client.username = (
+        args.username if args.username is not None else os.environ.get("EB_USERNAME")
+    )
+    explainaboard_client.api_key = (
+        args.api_key if args.api_key is not None else os.environ.get("EB_API_KEY")
+    )
     client = ExplainaboardClient()
     try:
         system_list: list[dict] = client.find_systems(

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -1,6 +1,6 @@
-import os
 import argparse
 import json
+import os
 import traceback
 
 import explainaboard_client


### PR DESCRIPTION
### Problem
The original command (as shown below) in README failed with 401 unauthorized (No authorization token provided), and the root cause is that `explainaboard_client.username` and `explainaboard_client.api_key` are both set to `None` (likely due to [this change](https://github.com/neulab/explainaboard_client/pull/40/commits/b216091d5fab293d75211e9131a93ed946ec9e45) to remove env vars from the library as suggested in the discussion). 

Original command
```
python -m explainaboard_client.cli.evaluate_system \
  --task text-classification \
  --system-name text-classification-test \
  --system-output-file example/data/sst2-lstm-output.txt \
  --system-output-file-type text \
  --dataset sst2 \
  --split test \
  --source-language 'en' 
```
### Solution
I read the env vars in the CLI parser and pass it into the library. I believe this adheres to the practice that "CLI is allowed to use reserved env vars, but not the library?" Looping in @odashi to double check if I'm on the right track
```
parser.add_argument(
    "--username",
    type=str,
    default=os.environ.get("EB_USERNAME"),
    help="Username used to sign in to ExplainaBoard. Defaults to the EB_USERNAME "
    "environment variable.",
)
```

