### PR TITLE
Support system tags in client and CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
         files: '\.py$'
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/pycqa/flake8.git
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/explainaboard_client/cli/evaluate_benchmark.py
+++ b/explainaboard_client/cli/evaluate_benchmark.py
@@ -67,6 +67,13 @@ def main():
     parser.add_argument(
         "--shared-users", type=str, nargs="+", help="Emails of users to share with"
     )
+    parser.add_argument(
+        "--system-tags",
+        type=str,
+        nargs="+",
+        help="User defined tags for the system,"
+        + "useful for searching and grouping systems",
+    )
     args = parser.parse_args()
 
     benchmark = args.benchmark
@@ -85,6 +92,7 @@ def main():
         raise ValueError("System output file names should start with number")
 
     shared_users = args.shared_users or []
+    system_tags = args.system_tags or []
     # Read system details file
     system_details = {}
     if args.system_details:
@@ -131,6 +139,7 @@ def main():
             dataset_split=dataset_split,
             shared_users=shared_users,
             system_details=system_details,
+            system_tags=system_tags,
         )
 
         create_props = SystemCreateProps(

--- a/explainaboard_client/cli/evaluate_system.py
+++ b/explainaboard_client/cli/evaluate_system.py
@@ -107,6 +107,13 @@ def main():
         "--shared-users", type=str, nargs="+", help="Emails of users to share with"
     )
     parser.add_argument(
+        "--system-tags",
+        type=str,
+        nargs="+",
+        help="User defined tags for the system,"
+        + "useful for searching and grouping systems",
+    )
+    parser.add_argument(
         "--report-file",
         type=str,
         help="A path to a file where the JSON report will be written",
@@ -138,6 +145,7 @@ def main():
             system_details_file=args.system_details_file,
             public=args.public,
             shared_users=args.shared_users,
+            system_tags=args.system_tags,
         )
         frontend = get_frontend(explainaboard_client.environment)
         sys_id = evaluation_data["system_id"]

--- a/explainaboard_client/cli/find_systems.py
+++ b/explainaboard_client/cli/find_systems.py
@@ -69,6 +69,13 @@ def main():
         nargs="+",
         help="Emails of users with which the system is shared",
     )
+    parser.add_argument(
+        "--system-tags",
+        type=str,
+        nargs="+",
+        help="User defined tags for the system,"
+        + "useful for searching and grouping systems",
+    )
     # ---- Display settings
     parser.add_argument(
         "--output-format",
@@ -120,6 +127,7 @@ def main():
             split=args.split,
             creator=args.creator,
             shared_users=args.shared_users,
+            system_tags=args.system_tags,
             page=args.page,
             page_size=args.page_size,
             sort_field=args.sort_field,

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -120,6 +120,7 @@ class ExplainaboardClient:
         system_details: dict | None = None,
         public: bool = False,
         shared_users: list[str] | None = None,
+        system_tags: list[str] | None = None,
     ) -> dict:
         """Evaluate a system output file and return a dictionary of results.
 
@@ -137,6 +138,8 @@ class ExplainaboardClient:
             system_details: File of system details in JSON format.
             public: Make the evaluation results public.
             shared_users: Emails of users to share with.
+            system_tags: User defined tags for the system,
+                useful for searching and grouping systems
         """
         # Sanity checks
         if not (source_language or target_language):
@@ -152,6 +155,7 @@ class ExplainaboardClient:
         source_language = source_language or target_language
         target_language = target_language or source_language
         shared_users = shared_users or []
+        system_tags = system_tags or []
 
         # Do the actual upload
         metadata = SystemMetadata(
@@ -163,6 +167,7 @@ class ExplainaboardClient:
             target_language=target_language,
             dataset_split=split,
             shared_users=shared_users,
+            system_tags=system_tags,
             system_details=system_details,
         )
         if dataset is not None:
@@ -210,6 +215,7 @@ class ExplainaboardClient:
         system_details_file: str | None = None,
         public: bool = False,
         shared_users: list[str] | None = None,
+        system_tags: list[str] | None = None,
     ) -> dict:
         """Evaluate a system output file and return a dictionary of results.
 
@@ -231,6 +237,8 @@ class ExplainaboardClient:
             system_details_file: File of system details in JSON format.
             public: Make the evaluation results public.
             shared_users: Emails of users to share with.
+            system_tags: User defined tags for the system,
+                useful for searching and grouping systems
         """
         # Sanity checks
         if not (source_language or target_language):
@@ -248,6 +256,7 @@ class ExplainaboardClient:
             custom_dataset_file_type, task
         )
         shared_users = shared_users or []
+        system_tags = system_tags or []
 
         # Read system details file
         system_details: dict = {}
@@ -266,6 +275,7 @@ class ExplainaboardClient:
             dataset_split=split,
             shared_users=shared_users,
             system_details=system_details,
+            system_tags=system_tags,
         )
         if dataset is not None:
             metadata.dataset_metadata_id = generate_dataset_id(dataset, sub_dataset)
@@ -324,6 +334,7 @@ class ExplainaboardClient:
         split: str | None = None,
         creator: str | None = None,
         shared_users: list[str] | None = None,
+        system_tags: list[str] | None = None,
         page: int = 0,
         page_size: int = 20,
         sort_field: str = "created_at",
@@ -339,6 +350,8 @@ class ExplainaboardClient:
             split: Dataset split.
             creator: Email of the creator of the system.
             shared_users: Emails of users with which the system is shared.
+            system_tags: User defined tags for the system,
+                useful for searching and grouping systems
             page: Which page to retrieve.
             page_size: The number of items on each page. Set to 0 for all.
             sort_field: Which field to sort by. Supports `created_at` and metric names
@@ -357,6 +370,7 @@ class ExplainaboardClient:
             split=split or "",
             creator=creator or "",
             shared_users=shared_users or [],
+            system_tags=system_tags or [],
             page=page,
             page_size=page_size,
             sort_field=sort_field,

--- a/explainaboard_client/tests/test_system.py
+++ b/explainaboard_client/tests/test_system.py
@@ -20,6 +20,7 @@ class TestSystem(TestEndpointsE2E):
             dataset="sst2",
             split="test",
             shared_users=["explainaboard@gmail.com"],
+            system_tags=["test_cli"],
         )
         sys_id = result["system_id"]
         try:
@@ -42,6 +43,7 @@ class TestSystem(TestEndpointsE2E):
             target_language="en",
             split="test",  # TODO(gneubig): required, but probably shouldn't be
             shared_users=["explainaboard@gmail.com"],
+            system_tags=["test_cli"],
         )
         # cleanup
         sys_id = result["system_id"]
@@ -61,6 +63,7 @@ class TestSystem(TestEndpointsE2E):
             split="test",
             system_details={"test": "test"},
             shared_users=["explainaboard@gmail.com"],
+            system_tags=["test_cli"],
         )
         sys_id = result["system_id"]
         try:
@@ -89,6 +92,7 @@ class TestSystem(TestEndpointsE2E):
             split="test",  # TODO(gneubig): required, but probably shouldn't be
             system_details={"test": "test"},
             shared_users=["explainaboard@gmail.com"],
+            system_tags=["test_cli"],
         )
         sys_id = result["system_id"]
         try:
@@ -111,13 +115,26 @@ class TestSystem(TestEndpointsE2E):
                 dataset="sst2",
                 split="test",
                 shared_users=["explainaboard@gmail.com"],
+                system_tags=["test_cli"],
             )
             system_ids.append(result["system_id"])
+
+        # test find by system_name
         all_systems = self._client.find_systems(system_name="test_cli")
         self.assertGreater(len(all_systems), 1)
         unique_names = {x["system_name"]: 0 for x in all_systems}
         self.assertIn("test_cli0", unique_names)
         self.assertIn("test_cli1", unique_names)
+
+        # test find by system_tag
+        all_systems = self._client.find_systems(
+            system_name="", system_tags=["test_cli"]
+        )
+        self.assertGreater(len(all_systems), 1)
+        unique_names = {x["system_name"]: 0 for x in all_systems}
+        self.assertIn("test_cli0", unique_names)
+        self.assertIn("test_cli1", unique_names)
+
         for x in system_ids:
             try:
                 self._client.delete_system(x)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={
         "console_scripts": [],
     },
-    install_requires=["explainaboard_api_client>=0.2.13", "tqdm"],
+    install_requires=["explainaboard_api_client>=0.2.20", "tqdm"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
- Support system tags in the following existing methods/files:
  - Client:
    - evaluate_system()
    - evaluate_system_file()
    - find_systems()
  - CLI:
    - evaluate_benchmark.py
    - evaluate_system.py
    - find_systems.py
- Modified test_systems.py to include test cases for system tags. 
- Updated explainaboard_api_client to >=0.2.20.
- Update flake8's URL to github.com as gitlab no longer supports it

ccing @PaulCCCCCCH for visibility