### PR TITLE
Add wrapper functions for tabular data (type: `pandas.DataFrame`)

### DIFF
--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -46,6 +46,7 @@ from explainaboard_client.utils import (
 )
 import pandas as pd
 
+
 class ExplainaboardClient:
     # ---- Initializers, etc.
     def __init__(self) -> None:
@@ -485,40 +486,45 @@ class ExplainaboardClient:
         """
         self._default_api.benchmark_delete_by_id(benchmark_id)
 
-    def _verify_column_names_for_dataset(self, columns:list[str], task:str):
+    def _verify_column_names_for_dataset(self, columns: list[str], task: str):
         task = TaskType(task)
         if task not in CUSTOM_DATASET_REQUIRED_COLUMNS:
             raise ValueError(
-                f"{task} is currently not supported for custom dataset evaluation or not supported by ExplainaBoard."
+                f"{task} is currently not supported for custom dataset "
+                "evaluation or not supported by ExplainaBoard."
             )
 
-        columns = set(columns)
+        columns_set = set(columns)
         required_columns = CUSTOM_DATASET_REQUIRED_COLUMNS[task]
         for col in required_columns:
-            if col not in columns:
+            if col not in columns_set:
                 raise ValueError(
-                    f"Column \"{col}\" is missing from the given columns({columns}). For task \"{task}\", the requred columns are: {required_columns}. "
+                    f'Column "{col}" is missing from the given columns '
+                    '({columns}). For task "{task}", the requred columns '
+                    "are: {required_columns}. "
                 )
-    
-    def _verify_column_names_for_output(self, columns:list[str], task:str):
+
+    def _verify_column_names_for_output(self, columns: list[str], task: str):
         task = TaskType(task)
         if task not in SYSTEM_OUTPUT_REQUIRED_COLUMNS:
-            raise ValueError(
-                f"{task} is currently not supported by ExplainaBoard."
-            )
+            raise ValueError(f"{task} is currently not supported by ExplainaBoard.")
 
-        columns = set(columns)
+        columns_set = set(columns)
         required_columns = SYSTEM_OUTPUT_REQUIRED_COLUMNS[task]
         for col in required_columns:
-            if col not in columns:
+            if col not in columns_set:
                 raise ValueError(
-                    f"Column \"{col}\" is missing from the given columns({columns}). For task \"{task}\", the requred columns for prediction are: {required_columns}. "
+                    f'Column "{col}" is missing from the given columns '
+                    '({columns}). For task "{task}", the requred columns '
+                    "for prediction are: {required_columns}. "
                 )
 
-    def wrap_tabular_dataset(self, dataset: pd.DataFrame, task: str, columns_to_analyze: list[str] = None) -> list[dict]:
+    def wrap_tabular_dataset(
+        self, dataset: pd.DataFrame, task: str, columns_to_analyze: list[str] = None
+    ) -> list[dict]:
         if not columns_to_analyze:
             columns_to_analyze = list(dataset.iloc[0].keys())
-        
+
         self._verify_column_names_for_dataset(columns_to_analyze, task)
 
         wrapped_dataset = []
@@ -528,11 +534,13 @@ class ExplainaboardClient:
                 new_row[col] = row[col]
             wrapped_dataset.append(new_row)
         return wrapped_dataset
-    
-    def wrap_tabular_output(self, output: pd.DataFrame, task: str, columns_to_analyze: list[str] = None) -> list[dict]:
+
+    def wrap_tabular_output(
+        self, output: pd.DataFrame, task: str, columns_to_analyze: list[str] = None
+    ) -> list[dict]:
         if not columns_to_analyze:
             columns_to_analyze = list(output.iloc[0].keys())
-        
+
         self._verify_column_names_for_output(columns_to_analyze, task)
 
         wrapped_output = []

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -6,7 +6,6 @@ import logging
 from multiprocessing.pool import ApplyResult
 import re
 from typing import Literal, Union
-import pandas as pd
 
 from explainaboard_api_client import __name__ as api_client_name
 from explainaboard_api_client import __version__ as api_client_version
@@ -33,13 +32,19 @@ from explainaboard_api_client.models import (
 import explainaboard_client
 from explainaboard_client.config import get_host
 from explainaboard_client.exceptions import APIVersionMismatchException
-from explainaboard_client.tasks import CUSTOM_DATASET_REQUIRED_COLUMNS, DEFAULT_METRICS, SYSTEM_OUTPUT_REQUIRED_COLUMNS, infer_file_type, TaskType
+from explainaboard_client.tasks import (
+    CUSTOM_DATASET_REQUIRED_COLUMNS,
+    DEFAULT_METRICS,
+    infer_file_type,
+    SYSTEM_OUTPUT_REQUIRED_COLUMNS,
+    TaskType,
+)
 from explainaboard_client.utils import (
     encode_file_to_base64,
     encode_string_to_base64,
     generate_dataset_id,
 )
-
+import pandas as pd
 
 class ExplainaboardClient:
     # ---- Initializers, etc.

--- a/explainaboard_client/tasks.py
+++ b/explainaboard_client/tasks.py
@@ -84,6 +84,53 @@ DEFAULT_METRICS: dict[TaskType, list[str]] = {
 
 FILE_SUFFIX_MAP = {"txt": "text"}
 
+CUSTOM_DATASET_REQUIRED_COLUMNS: dict[TaskType, list[str]] = {
+    TaskType.text_classification: ["text", "true_label"],
+    TaskType.qa_extractive: ["context", "question", "answers"],
+    TaskType.summarization: ["source", "reference"],
+    TaskType.machine_translation: ["source", "reference"],
+    TaskType.text_pair_classification: ["text1", "text2", "true_label"],
+    TaskType.aspect_based_sentiment_classification: ["aspect", "text", "true_label"],
+    TaskType.kg_link_tail_prediction: [
+        "true_head",
+        "true_head_decipher",
+        "true_link",
+        "true_tail",
+        "true_tail_decipher",
+    ],
+    TaskType.qa_multiple_choice: ["context", "options", "question", "answers"],
+    TaskType.qa_open_domain: ["question", "answers"],
+    TaskType.conditional_generation: ["source", "reference"],
+    TaskType.language_modeling: ["text"],
+    TaskType.cloze_mutiple_choice: ["context", "options", "question_mark", "answers"],
+    TaskType.cloze_generative: ["context", "hint", "question_mark", "answers"],
+    TaskType.grammatical_error_correction: ["text", "edits"],
+    TaskType.tabular_regression: ["true_value"],
+    TaskType.tabular_classification: ["true_label"],
+}
+
+SYSTEM_OUTPUT_REQUIRED_COLUMNS: dict[TaskType, list[str]] = {
+    TaskType.text_classification: ["predicted_label"],
+    TaskType.qa_extractive: ["predicted_answers"],
+    TaskType.summarization: ["hypothesis"],
+    TaskType.machine_translation: ["hypothesis"],
+    TaskType.text_pair_classification: ["predicted_label"],
+    TaskType.aspect_based_sentiment_classification: ["predicted_label"],
+    TaskType.kg_link_tail_prediction: ["predict", "predictions", "true_rank"],
+    TaskType.qa_multiple_choice: ["predicted_answers"],
+    TaskType.qa_open_domain: ["predicted_answer"],
+    TaskType.qa_tat: ["predicted_answer", "predicted_answer_scale"],
+    TaskType.conditional_generation: ["hypothesis"],
+    TaskType.language_modeling: ["log_probs"],
+    TaskType.cloze_mutiple_choice: ["predicted_answers"],
+    TaskType.cloze_generative: ["predicted_answers"],
+    TaskType.grammatical_error_correction: ["predicted_edits"],
+    TaskType.nlg_meta_evaluation: ["auto_scores"],
+    TaskType.tabular_regression: ["predicted_value"],
+    TaskType.tabular_classification: ["predicted_label"],
+    TaskType.argument_pair_extraction: ["pred_tags"],
+}
+
 
 def infer_file_type(file_path: str | None, task: TaskType):
     """

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={
         "console_scripts": [],
     },
-    install_requires=["explainaboard_api_client>=0.2.20", "tqdm"],
+    install_requires=["explainaboard_api_client>=0.2.20", "tqdm", "pandas"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
Closes #56 

This PR adds two functions `wrap_tabular_dataset()` and `wrap_tabular_output()`.
This makes it easier for `Dataframe` datasets/system outputs in memory easier to use.

The reason for the separation of "dataset" and "output" is because:
1. users may be uploading to a datalab dataset (which we don't need to upload "dataset")
2. "dataset" and "output" used different columns (e.g., "true_label" vs "predicted_label")

## Example Usage
```py3
import explainaboard_client
import pandas as pd

client = explainaboard_client.ExplainaboardClient()

data = pd.DataFrame(
       [['snli-dataset', 'This church choir sings to the masses as they sing joyous songs from the book at a church.', 'The church has cracks in the ceiling.', 'neutral'], 
       ['snli-dataset', 'This church choir sings to the masses as they sing joyous songs from the book at a church.', 'The church is filled with song.', 'entailment'], 
       ['snli-dataset', 'This church choir sings to the masses as they sing joyous songs from the book at a church.', 'A choir singing at a baseball game.', 'contradiction'], 
       ['snli-dataset', 'A woman with a green headscarf, blue shirt and a very big grin.', 'The woman is young.', 'neutral'],
       ['snli-dataset', 'A woman with a green headscarf, blue shirt and a very big grin.', 'The woman is very happy.', 'entailment'], 
       ['snli-dataset', 'A woman with a green headscarf, blue shirt and a very big grin.', 'The woman has been shot.', 'contradiction']],
       columns=['dataset', 'text1', 'text2', 'true_label'])

predict_data = pd.DataFrame(
       [['neutral'], 
       ['neutral'], 
       ['neutral'], 
       ['neutral'], 
       ['neutral'], 
       ['neutral']],
       columns=['predicted_label'])

wrapped_dataset = client.wrap_tabular_dataset(
    data, 
    task="text-pair-classification", 
    columns_to_analyze=['text1', 'text2', 'true_label']
)
wrapped_output = client.wrap_tabular_output(
    predict_data, 
    task="text-pair-classification"
)

evaluation_result = client.evaluate_system(
    task='text-pair-classification',
    system_name='text-pair-classification-test',
    system_output=wrapped_output,
    custom_dataset=wrapped_dataset,
    split='test',
    source_language='en',
    system_details={}
)
```

## Next Steps
- add documentation with example on how to use these functions