### PR TITLE
Add a property in client to disable API version checking

### DIFF
--- a/explainaboard_client/__init__.py
+++ b/explainaboard_client/__init__.py
@@ -9,3 +9,4 @@ __all__ = ["ExplainaboardClient"]
 username: str | None = None
 api_key: str | None = None
 environment: Literal["main", "staging", "local"] = "main"
+check_api_version: bool = True

--- a/explainaboard_client/client.py
+++ b/explainaboard_client/client.py
@@ -92,20 +92,23 @@ class ExplainaboardClient:
 
             return wrapper
 
-        # The code below does two things:
-        # 1. modifies the api client's validation rule of every endpoint
-        # to allow us to specify the X-API-version header in every request
-        # without having to define it in openapi.yaml
-        # 2. decorates the call_with_http_info of every endpoint
-        # so the api version header is attached in every request.
-        for v in vars(self._default_api).values():
-            if type(v) == Endpoint:
-                v.params_map["all"].append(self._api_version_param)
-                v.openapi_types[self._api_version_param] = (str,)
-                v.attribute_map[self._api_version_param] = self._api_version_header
-                v.location_map[self._api_version_param] = "header"
+        if explainaboard_client.check_api_version:
+            # The code below does two things:
+            # 1. modifies the api client's validation rule of every endpoint
+            # to allow us to specify the X-API-version header in every request
+            # without having to define it in openapi.yaml
+            # 2. decorates the call_with_http_info of every endpoint
+            # so the api version header is attached in every request.
+            for v in vars(self._default_api).values():
+                if type(v) == Endpoint:
+                    v.params_map["all"].append(self._api_version_param)
+                    v.openapi_types[self._api_version_param] = (str,)
+                    v.attribute_map[self._api_version_param] = self._api_version_header
+                    v.location_map[self._api_version_param] = "header"
 
-                v.call_with_http_info = with_check_api_version(v.call_with_http_info)
+                    v.call_with_http_info = with_check_api_version(
+                        v.call_with_http_info
+                    )
 
     def close(self):
         self._default_api.api_client.close()

--- a/explainaboard_client/tests/test_benchmark.py
+++ b/explainaboard_client/tests/test_benchmark.py
@@ -45,6 +45,10 @@ class TestBenchmark(TestEndpointsE2E):
             # check all old values match
             del result["config"]["name"]
             del new_result["config"]["name"]
+            # the "Benchmark" schema contains a "time" field
+            # that is updated on every GET request
+            del result["time"]
+            del new_result["time"]
             self.assertDictEqual(result, new_result)
 
         finally:

--- a/explainaboard_client/tests/test_check_api_version.py
+++ b/explainaboard_client/tests/test_check_api_version.py
@@ -6,21 +6,23 @@ from unittest.mock import patch
 from explainaboard_api_client.exceptions import ApiException
 import explainaboard_client
 from explainaboard_client.cli import delete_systems
+from explainaboard_client.client import ExplainaboardClient
 from explainaboard_client.exceptions import APIVersionMismatchException
 from explainaboard_client.tests.test_utils import TestEndpointsE2E
 
 
+def _with_wrong_api_version(func: Callable) -> Callable:
+    def wrapper(self, *args, **kwargs):
+        prev_version = self._client._api_client_version
+        self._client._api_client_version = "0.0.0"
+        result = func(self, *args, **kwargs)
+        self._client._api_client_version = prev_version
+        return result
+
+    return wrapper
+
+
 class TestCheckAPIVersion(TestEndpointsE2E):
-    def _with_wrong_api_version(func: Callable) -> Callable:
-        def wrapper(self, *args, **kwargs):
-            prev_version = self._client._api_client_version
-            self._client._api_client_version = "0.0.0"
-            result = func(self, *args, **kwargs)
-            self._client._api_client_version = prev_version
-            return result
-
-        return wrapper
-
     def test_check_api_version_match(self):
         info = self._client.info_get()
         self.assertEqual(info["api_version"], self._client._api_client_version)
@@ -58,3 +60,16 @@ class TestCheckAPIVersion(TestEndpointsE2E):
                     (ApiException, APIVersionMismatchException, SystemExit)
                 ):
                     delete_systems.main()
+
+
+class TestCheckAPIVersionDisabled(TestEndpointsE2E):
+    def setUp(self):
+        super().setUp()
+        # disable API version checking
+        explainaboard_client.check_api_version = False
+        self._client = ExplainaboardClient()
+
+    @_with_wrong_api_version
+    def test_check_api_version_disabled(self):
+        # should execute with no exception raised
+        _ = self._client.info_get()


### PR DESCRIPTION
Users can do the following in the env setup to disable API version checking
```python
explainaboard_client.check_api_version = False # this line
client = explainaboard_client.ExplainaboardClient()
```

Fix test by `del`ing the `time` field, which is updated on every GET request.

Add a test to ensure the disable property works