### PR TITLE
Add benchmark schema under example dir

### DIFF
--- a/example/benchmark/config_schema.py
+++ b/example/benchmark/config_schema.py
@@ -1,0 +1,65 @@
+example_config = {
+    # == REQUIRED FIELDS ==
+    "id": "example",
+    "is_private": False,
+    "shared_users": ["example@gmail.com"],
+    "name": "Example Benchmark",
+    # A parent benchmark id that this benchmark inherits config from.
+    # If this benchmark doesn't inherit any configs,
+    # the field must be an empty string
+    "parent": "",
+    "description": "Example Description",
+    # == POTENTIALLY REQUIRED FIELDS ==
+    # "views" is required if "parent" is an empty string
+    "views": [
+        {
+            "name": "Example View",
+            "operations": [{"op": "mean", "group_by": ["sub_dataset"]}],
+        }
+    ],
+    # == OPTIONAL FIELDS ==
+    # Specify "abstract" to indicate this doesn't
+    # fully specify a benchmark
+    "type": "abstract",
+    # Please contact us and send us your logo.
+    # We will add it to our image store and update the link.
+    "logo": "",
+    "contact": "example@gmail.com",
+    "homepage": "https://example.com",
+    "paper": {
+        # REQUIRED if paper is not None
+        "title": "Example Paper",
+        "url": "www.example.com",
+    },
+    "metrics": [
+        {
+            # REQUIRED for each metrics element
+            "name": "ExampleMetric",
+            # OPTIONAL
+            "weight": 1.0,
+            "default": 1.0,
+        }
+    ],
+    "datasets": [
+        {
+            # REQUIRED for each datasets element
+            "dataset_name": "example_dataset",
+            # OPTIONAL
+            "sub_dataset": "example_sub_dataset",
+            "split": "test",
+            "metrics": [
+                {
+                    # REQUIRED for each metrics element
+                    "name": "ExampleMetric",
+                    # OPTIONAL
+                    "weight": 1.0,
+                    "default": 1.0,
+                }
+            ],
+        }
+    ],
+    "system_query": {
+        "task_name": "example-task",
+    },
+    "default_views": ["Example View"],
+}

--- a/explainaboard_client/tests/test_benchmark.py
+++ b/explainaboard_client/tests/test_benchmark.py
@@ -45,6 +45,10 @@ class TestBenchmark(TestEndpointsE2E):
             # check all old values match
             del result["config"]["name"]
             del new_result["config"]["name"]
+            # the "Benchmark" schema contains a "time" field
+            # that is updated on every GET request
+            del result["time"]
+            del new_result["time"]
             self.assertDictEqual(result, new_result)
 
         finally:


### PR DESCRIPTION
Added a benchmark schema under `/example` for users' reference. I chose Python instead of JSON so comments can be added easily without breaking the syntax.

Fix test by `del`ing the `time` field, which is updated on every GET request.