### PR TITLE
Disable checking api version in example/scikit-learn

### DIFF
--- a/example/scikit-learn/README.md
+++ b/example/scikit-learn/README.md
@@ -19,6 +19,7 @@ y_predict = classifier.predict(X_test)
 # Create the ExplainaBoard client, wrap the data
 explainaboard_client.username = os.environ.get("EB_USERNAME")
 explainaboard_client.api_key = os.environ.get("EB_API_KEY")
+explainaboard_client.check_api_version = False
 client = explainaboard_client.ExplainaboardClient()
 
 # Wrap the data in ExplainaBoard format

--- a/example/scikit-learn/main.py
+++ b/example/scikit-learn/main.py
@@ -20,6 +20,7 @@ y_predict = classifier.predict(X_test)
 # Create the ExplainaBoard client, wrap the data, and evaluate
 explainaboard_client.username = os.environ.get("EB_USERNAME")
 explainaboard_client.api_key = os.environ.get("EB_API_KEY")
+explainaboard_client.check_api_version = False
 client = explainaboard_client.ExplainaboardClient()
 
 dataset_wrapped = explainaboard_client.wrap_tabular_dataset(


### PR DESCRIPTION
A data scientist has reported facing an API version mismatch exception. Because our prod server uses API client version 0.2.17 and the CLI uses 0.2.23, we need to disable version checking. 

Alternatively, we can also set `explainaboard-api-client==0.2.17` in requirements.txt. I don't really have a preference between these two.

In the long run, I think a better way is to have two branches `dev` and `main`. The former's version will align with our dev server and the latter with our prod server.